### PR TITLE
Dependency update

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,6 @@ More info can be read here: https://github.com/NatLibFi/marc-record-js
 
 ## License and copyright
 
-Copyright (c) 2020-2023 **University Of Helsinki (The National Library Of Finland)**
+Copyright (c) 2020-2024 **University Of Helsinki (The National Library Of Finland)**
 
 This project's source code is licensed under the terms of **MIT** or any later version.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2036,9 +2036,9 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-8.0.2.tgz",
-			"integrity": "sha512-aCF5zgzlZ6YsQpGpJEpEfb0t/5gF4pl8exT0R/lFUxp63VkHz0OoX0mhRDhC0UYf4JufkrvkNMK2WwZFTSAT2Q==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-8.1.0.tgz",
+			"integrity": "sha512-kezWNVlOsBNdETT5xvoVU5d1308duKg/UebhXMavjDPbNO0IdoWRcFKUvS8ThV0hiVQ7ErlxK5DwnSJY25nODw==",
 			"dependencies": {
 				"debug": "^4.3.4",
 				"jsonschema": "^1.4.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/marc-record-merge",
-	"version": "7.0.1",
+	"version": "7.0.2-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/marc-record-merge",
-			"version": "7.0.1",
+			"version": "7.0.2-alpha.1",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^8.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/marc-record-merge",
-	"version": "7.0.2-alpha.1",
+	"version": "7.0.2-alpha.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/marc-record-merge",
-			"version": "7.0.2-alpha.1",
+			"version": "7.0.2-alpha.2",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/marc-record": "^8.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,25 +9,25 @@
 			"version": "7.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^8.0.2",
+				"@natlibfi/marc-record": "^8.1.0",
 				"debug": "^4.3.4",
 				"normalize-diacritics": "^2.14.0"
 			},
 			"devDependencies": {
 				"@babel/cli": "^7.23.4",
-				"@babel/core": "^7.23.6",
-				"@babel/preset-env": "^7.23.6",
-				"@babel/register": "^7.22.15",
-				"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
-				"@natlibfi/fixugen": "^2.0.3",
-				"@natlibfi/fixura": "^3.0.3",
+				"@babel/core": "^7.23.7",
+				"@babel/preset-env": "^7.23.8",
+				"@babel/register": "^7.23.7",
+				"@natlibfi/eslint-config-melinda-backend": "^3.0.4",
+				"@natlibfi/fixugen": "^2.0.4",
+				"@natlibfi/fixura": "^3.0.4",
 				"babel-plugin-istanbul": "^6.1.1",
 				"babel-plugin-rewire": "^1.2.0",
-				"chai": "^4.3.10",
+				"chai": "^4.4.1",
 				"cross-env": "^7.0.3",
 				"eslint": "^8.56.0",
 				"mocha": "^10.2.0",
-				"nodemon": "^3.0.2",
+				"nodemon": "^3.0.3",
 				"nyc": "^15.1.0"
 			},
 			"engines": {
@@ -108,9 +108,9 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.6.tgz",
-			"integrity": "sha512-FxpRyGjrMJXh7X3wGLGhNDCRiwpWEF74sKjTLDJSG5Kyvow3QZaG0Adbqzi9ZrVjTWpsX+2cxWXD71NMg93kdw==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
+			"integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
@@ -118,10 +118,10 @@
 				"@babel/generator": "^7.23.6",
 				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.23.6",
+				"@babel/helpers": "^7.23.7",
 				"@babel/parser": "^7.23.6",
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.6",
+				"@babel/traverse": "^7.23.7",
 				"@babel/types": "^7.23.6",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
@@ -211,9 +211,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.6.tgz",
-			"integrity": "sha512-cBXU1vZni/CpGF29iTu4YRbOZt3Wat6zCoMDxRF1MayiEc4URxOj31tT65HUM0CRpMowA3HCJaAOVOUnMf96cw==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.7.tgz",
+			"integrity": "sha512-xCoqR/8+BoNnXOY7RVSgv6X+o7pmT5q1d+gGcRlXYkI+9B31glE4jeejhKVpA04O1AtzOt7OSQ6VYKP5FcRl9g==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
@@ -251,9 +251,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz",
-			"integrity": "sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.5.0.tgz",
+			"integrity": "sha512-NovQquuQLAQ5HuyjCz7WQP9MjRj7dx++yspwiyUiGl9ZyadHRSql1HZh5ogRd8W8w6YM6EQ/NTB8rgjLt5W65Q==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.22.6",
@@ -476,13 +476,13 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.6.tgz",
-			"integrity": "sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
+			"integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.6",
+				"@babel/traverse": "^7.23.7",
 				"@babel/types": "^7.23.6"
 			},
 			"engines": {
@@ -548,9 +548,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.3.tgz",
-			"integrity": "sha512-XaJak1qcityzrX0/IU5nKHb34VaibwP3saKqG6a/tppelgllOH13LUann4ZCIBcVOeE6H18K4Vx9QKkVww3z/w==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.23.7.tgz",
+			"integrity": "sha512-LlRT7HgaifEpQA1ZgLVOIJZZFVPWN5iReq/7/JixwBtwcoeVGDBD53ZV28rrsLYOZs1Y/EHhA8N/Z6aazHR8cw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
@@ -826,9 +826,9 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.23.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.4.tgz",
-			"integrity": "sha512-efdkfPhHYTtn0G6n2ddrESE91fgXxjlqLsnUtPWnJs4a4mZIbUaK7ffqKIIUKXSHwcDvaCVX6GXkaJJFqtX7jw==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.7.tgz",
+			"integrity": "sha512-PdxEpL71bJp1byMG0va5gwQcXHxuEYC/BgI/e88mGTtohbZN28O5Yit0Plkkm/dBzCF/BxmbNcses1RH1T+urA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.22.20",
@@ -924,16 +924,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.5.tgz",
-			"integrity": "sha512-jvOTR4nicqYC9yzOHIhXG5emiFEOpappSJAl73SDSEDcybD+Puuze8Tnpb9p9qEyYup24tq891gkaygIFvWDqg==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.23.8.tgz",
+			"integrity": "sha512-yAYslGsY1bX6Knmg46RjiCiNSwJKv2IUC8qOdYKqMMr0491SXFhcHqOdRDeCRohOOIzwN/90C6mQ9qAKgrP7dg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
-				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
-				"@babel/helper-optimise-call-expression": "^7.22.5",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/helper-replace-supers": "^7.22.20",
 				"@babel/helper-split-export-declaration": "^7.22.6",
@@ -1584,9 +1583,9 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.6.tgz",
-			"integrity": "sha512-2XPn/BqKkZCpzYhUUNZ1ssXw7DcXfKQEjv/uXZUXgaebCMYmkEsfZ2yY+vv+xtXv50WmL5SGhyB6/xsWxIvvOQ==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.8.tgz",
+			"integrity": "sha512-lFlpmkApLkEP6woIKprO6DO60RImpatTQKtz4sUcDjVcK8M8mQ4sZsuxaTMNOZf0sqAq/ReYW1ZBHnOQwKpLWA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.23.5",
@@ -1595,7 +1594,7 @@
 				"@babel/helper-validator-option": "^7.23.5",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
 				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.23.3",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.3",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.23.7",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
 				"@babel/plugin-syntax-async-generators": "^7.8.4",
 				"@babel/plugin-syntax-class-properties": "^7.12.13",
@@ -1616,13 +1615,13 @@
 				"@babel/plugin-syntax-top-level-await": "^7.14.5",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
 				"@babel/plugin-transform-arrow-functions": "^7.23.3",
-				"@babel/plugin-transform-async-generator-functions": "^7.23.4",
+				"@babel/plugin-transform-async-generator-functions": "^7.23.7",
 				"@babel/plugin-transform-async-to-generator": "^7.23.3",
 				"@babel/plugin-transform-block-scoped-functions": "^7.23.3",
 				"@babel/plugin-transform-block-scoping": "^7.23.4",
 				"@babel/plugin-transform-class-properties": "^7.23.3",
 				"@babel/plugin-transform-class-static-block": "^7.23.4",
-				"@babel/plugin-transform-classes": "^7.23.5",
+				"@babel/plugin-transform-classes": "^7.23.8",
 				"@babel/plugin-transform-computed-properties": "^7.23.3",
 				"@babel/plugin-transform-destructuring": "^7.23.3",
 				"@babel/plugin-transform-dotall-regex": "^7.23.3",
@@ -1664,9 +1663,9 @@
 				"@babel/plugin-transform-unicode-regex": "^7.23.3",
 				"@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.6",
-				"babel-plugin-polyfill-corejs3": "^0.8.5",
-				"babel-plugin-polyfill-regenerator": "^0.5.3",
+				"babel-plugin-polyfill-corejs2": "^0.4.7",
+				"babel-plugin-polyfill-corejs3": "^0.8.7",
+				"babel-plugin-polyfill-regenerator": "^0.5.4",
 				"core-js-compat": "^3.31.0",
 				"semver": "^6.3.1"
 			},
@@ -1692,15 +1691,15 @@
 			}
 		},
 		"node_modules/@babel/register": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.22.15.tgz",
-			"integrity": "sha512-V3Q3EqoQdn65RCgTLwauZaTfd1ShhwPmbBv+1dkZV/HpCGMKVyn6oFcRlI7RaKqiDQjX2Qd3AuoEguBgdjIKlg==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.23.7.tgz",
+			"integrity": "sha512-EjJeB6+kvpk+Y5DAkEAmbOBEFkh9OASx0huoEkqYTFxAZHzOAX2Oh5uwAUuL2rUddqfM0SA+KPXV2TbzoZ2kvQ==",
 			"dev": true,
 			"dependencies": {
 				"clone-deep": "^4.0.1",
 				"find-cache-dir": "^2.0.0",
 				"make-dir": "^2.1.0",
-				"pirates": "^4.0.5",
+				"pirates": "^4.0.6",
 				"source-map-support": "^0.5.16"
 			},
 			"engines": {
@@ -1717,9 +1716,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
-			"integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
+			"version": "7.23.8",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
+			"integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
 			"dev": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -1743,9 +1742,9 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.6",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.6.tgz",
-			"integrity": "sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==",
+			"version": "7.23.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+			"integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.23.5",
@@ -1842,6 +1841,16 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
 			"version": "13.24.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
@@ -1869,6 +1878,18 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/@eslint/eslintrc/node_modules/type-fest": {
 			"version": "0.20.2",
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
@@ -1891,17 +1912,39 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array": {
-			"version": "0.11.13",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-			"integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+			"version": "0.11.14",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
 			"dev": true,
 			"dependencies": {
-				"@humanwhocodes/object-schema": "^2.0.1",
-				"debug": "^4.1.1",
+				"@humanwhocodes/object-schema": "^2.0.2",
+				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
 			"engines": {
 				"node": ">=10.10.0"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@humanwhocodes/module-importer": {
@@ -1918,9 +1961,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/object-schema": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-			"integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
 			"dev": true
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -1987,9 +2030,9 @@
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
-			"version": "0.3.20",
-			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-			"integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+			"version": "0.3.22",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+			"integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -1997,9 +2040,9 @@
 			}
 		},
 		"node_modules/@natlibfi/eslint-config-melinda-backend": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.3.tgz",
-			"integrity": "sha512-tkfBuhpQ59D/TXBq+a0ntw0tdjS8h2rd59WF7pbASz/V/yBIwAgArZ+f1cVC8ybDsBlcZsLTb/v5V/7DxExBCw==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/eslint-config-melinda-backend/-/eslint-config-melinda-backend-3.0.4.tgz",
+			"integrity": "sha512-0empL237DfX80LCFC7+pMXojsfMThBblViIT1MUllyYF0yNvmGSFTL1Ycf/HDfz61uX3MxJhE+ab3mQUWZpM3w==",
 			"dev": true,
 			"dependencies": {
 				"@babel/eslint-parser": "^7.22.15",
@@ -2015,18 +2058,18 @@
 			}
 		},
 		"node_modules/@natlibfi/fixugen": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-2.0.3.tgz",
-			"integrity": "sha512-67FPpoQKJvgdvXeJCRro1K3xMSXku75hRwHgVkqJ5MAsCGQU54aeHWskQpPin21I88D55J1DOh5+1Fta54ncfw==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen/-/fixugen-2.0.4.tgz",
+			"integrity": "sha512-GT/80Mv1vepF0WRaLpiA/wpUkjnYWVJ6izsqp9xXJqwX8JaO50O/fyQcZyxkE2zHWwiUsJW3PqD22ii7G/dgQA==",
 			"dev": true,
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@natlibfi/fixura": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixura/-/fixura-3.0.3.tgz",
-			"integrity": "sha512-TP6df4z9s1S/A7TqSNFVvVqUQxDJs3hJPsfnYZEMMiRfh4AUMTtaBOZGF2d1RAv25coLG1X4qXbm8N9E533cBg==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixura/-/fixura-3.0.4.tgz",
+			"integrity": "sha512-rJMOCmvlNNNlxYU0gFpuRLUEH3/sPsZQK3F2+v/ldjZKBRIaRHlBb8IXGyw/Loekr7+TAfbI5wFieuvO+2+0UQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/register": "^7.22.15"
@@ -2111,13 +2154,13 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.15.0.tgz",
-			"integrity": "sha512-+BdvxYBltqrmgCNu4Li+fGDIkW9n//NrruzG9X1vBzaNK+ExVXPoGB71kneaVw/Jp+4rH/vaMAGC6JfMbHstVg==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.19.1.tgz",
+			"integrity": "sha512-4CdXYjKf6/6aKNMSly/BP4iCSOpvMmqtDzRtqFyyAae3z5kkqEjKndR5vDHL8rSuMIIWP8u4Mw4VxLyxZW6D5w==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.15.0",
-				"@typescript-eslint/visitor-keys": "6.15.0"
+				"@typescript-eslint/types": "6.19.1",
+				"@typescript-eslint/visitor-keys": "6.19.1"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2128,13 +2171,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.15.0.tgz",
-			"integrity": "sha512-CnmHKTfX6450Bo49hPg2OkIm/D/TVYV7jO1MCfPYGwf6x3GO0VU8YMO5AYMn+u3X05lRRxA4fWCz87GFQV6yVQ==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.19.1.tgz",
+			"integrity": "sha512-0vdyld3ecfxJuddDjACUvlAeYNrHP/pDeQk2pWBR2ESeEzQhg52DF53AbI9QCBkYE23lgkhLCZNkHn2hEXXYIg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.15.0",
-				"@typescript-eslint/utils": "6.15.0",
+				"@typescript-eslint/typescript-estree": "6.19.1",
+				"@typescript-eslint/utils": "6.19.1",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2155,9 +2198,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.15.0.tgz",
-			"integrity": "sha512-yXjbt//E4T/ee8Ia1b5mGlbNj9fB9lJP4jqLbZualwpP2BCQ5is6BcWwxpIsY4XKAhmdv3hrW92GdtJbatC6dQ==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.19.1.tgz",
+			"integrity": "sha512-6+bk6FEtBhvfYvpHsDgAL3uo4BfvnTnoge5LrrCj2eJN8g3IJdLTD4B/jK3Q6vo4Ql/Hoip9I8aB6fF+6RfDqg==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2168,16 +2211,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.15.0.tgz",
-			"integrity": "sha512-7mVZJN7Hd15OmGuWrp2T9UvqR2Ecg+1j/Bp1jXUEY2GZKV6FXlOIoqVDmLpBiEiq3katvj/2n2mR0SDwtloCew==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.19.1.tgz",
+			"integrity": "sha512-aFdAxuhzBFRWhy+H20nYu19+Km+gFfwNO4TEqyszkMcgBDYQjmPJ61erHxuT2ESJXhlhrO7I5EFIlZ+qGR8oVA==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.15.0",
-				"@typescript-eslint/visitor-keys": "6.15.0",
+				"@typescript-eslint/types": "6.19.1",
+				"@typescript-eslint/visitor-keys": "6.19.1",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
+				"minimatch": "9.0.3",
 				"semver": "^7.5.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2228,17 +2272,17 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.15.0.tgz",
-			"integrity": "sha512-eF82p0Wrrlt8fQSRL0bGXzK5nWPRV2dYQZdajcfzOD9+cQz9O7ugifrJxclB+xVOvWvagXfqS4Es7vpLP4augw==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.19.1.tgz",
+			"integrity": "sha512-JvjfEZuP5WoMqwh9SPAPDSHSg9FBHHGhjPugSRxu5jMfjvBpq5/sGTD+9M9aQ5sh6iJ8AY/Kk/oUYVEMAPwi7w==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.15.0",
-				"@typescript-eslint/types": "6.15.0",
-				"@typescript-eslint/typescript-estree": "6.15.0",
+				"@typescript-eslint/scope-manager": "6.19.1",
+				"@typescript-eslint/types": "6.19.1",
+				"@typescript-eslint/typescript-estree": "6.19.1",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -2286,12 +2330,12 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.15.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.15.0.tgz",
-			"integrity": "sha512-1zvtdC1a9h5Tb5jU9x3ADNXO9yjP8rXlaoChu0DQX40vf5ACVpYIVIZhIMZ6d5sDXH7vq4dsZBT1fEGj8D2n2w==",
+			"version": "6.19.1",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.19.1.tgz",
+			"integrity": "sha512-gkdtIO+xSO/SmI0W68DBg4u1KElmIUo3vXzgHyGPs6cxgB0sa3TlptRAAE0hUY1hM6FcDKEv7aIwiTGm76cXfQ==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.15.0",
+				"@typescript-eslint/types": "6.19.1",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -2327,9 +2371,9 @@
 			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "8.11.2",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-			"integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+			"version": "8.11.3",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
 			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2481,13 +2525,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.7",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.7.tgz",
-			"integrity": "sha512-LidDk/tEGDfuHW2DWh/Hgo4rmnw3cduK6ZkOI1NPFceSK3n/yAGeOsNT7FLnSGHkXj3RHGSEVkN3FsCTY6w2CQ==",
+			"version": "0.4.8",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.8.tgz",
+			"integrity": "sha512-OtIuQfafSzpo/LhnJaykc0R/MMnuLSSVjVYy9mHArIZ9qTCSZ6TpWCuEKZYVoN//t8HqBNScHrOtCrIK5IaGLg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-define-polyfill-provider": "^0.4.4",
+				"@babel/helper-define-polyfill-provider": "^0.5.0",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -2507,13 +2551,29 @@
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
-		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.5.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.4.tgz",
-			"integrity": "sha512-S/x2iOCvDaCASLYsOOgWOq4bCfKYVqvO/uxjkaYyZ3rVsVE3CeAI/c84NpyuBBymEgNvHgjEot3a9/Z/kXvqsg==",
+		"node_modules/babel-plugin-polyfill-corejs3/node_modules/@babel/helper-define-polyfill-provider": {
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz",
+			"integrity": "sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.4"
+				"@babel/helper-compilation-targets": "^7.22.6",
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"debug": "^4.1.1",
+				"lodash.debounce": "^4.0.8",
+				"resolve": "^1.14.2"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+			}
+		},
+		"node_modules/babel-plugin-polyfill-regenerator": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.5.tgz",
+			"integrity": "sha512-OJGYZlhLqBh2DDHeqAxWB1XIvr49CxiJ2gIt61/PU55CQK4Z58OzMqjDe1zwQdQk+rBYsRc+1rJmdajM3gimHg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^0.5.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -2541,13 +2601,12 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
 			"dev": true,
 			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
+				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/braces": {
@@ -2655,9 +2714,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001570",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001570.tgz",
-			"integrity": "sha512-+3e0ASu4sw1SWaoCtvPeyXp+5PsjigkSt8OXZbF9StH5pQWbxEjLAZE3n8Aup5udop1uRiKA7a4utUk/uoSpUw==",
+			"version": "1.0.30001580",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001580.tgz",
+			"integrity": "sha512-mtj5ur2FFPZcCEpXFy8ADXbDACuNFXg6mxVDqp7tqooX6l3zwm+d8EPoeOSIFRDvHs8qu7/SLFOGniULkcH2iA==",
 			"dev": true,
 			"funding": [
 				{
@@ -2675,9 +2734,9 @@
 			]
 		},
 		"node_modules/chai": {
-			"version": "4.3.10",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.3.10.tgz",
-			"integrity": "sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
+			"integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
 			"dev": true,
 			"dependencies": {
 				"assertion-error": "^1.1.0",
@@ -2822,9 +2881,9 @@
 			"dev": true
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.34.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.34.0.tgz",
-			"integrity": "sha512-4ZIyeNbW/Cn1wkMMDy+mvrRUxrwFNjKwbhCfQpDd+eLgYipDqp8oGFGtLmhh18EDPKA0g3VUBYOxQGGwvWLVpA==",
+			"version": "3.35.1",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.35.1.tgz",
+			"integrity": "sha512-sftHa5qUJY3rs9Zht1WEnmkvXputCyDBczPnr7QDgL8n3qrF3CMXY4VPSYtOLLiOUJcah2WNXREd48iOl6mQIw==",
 			"dev": true,
 			"dependencies": {
 				"browserslist": "^4.22.2"
@@ -2967,9 +3026,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.615",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.615.tgz",
-			"integrity": "sha512-/bKPPcgZVUziECqDc+0HkT87+0zhaWSZHNXqF8FLd2lQcptpmUFwoCSWjCdOng9Gdq+afKArPdEg/0ZW461Eng==",
+			"version": "1.4.645",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.645.tgz",
+			"integrity": "sha512-EeS1oQDCmnYsRDRy2zTeC336a/4LZ6WKqvSaM1jLocEk5ZuyszkQtCpsqvuvaIXGOUjwtvF6LTcS8WueibXvSw==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -3316,6 +3375,16 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true
 		},
+		"node_modules/eslint/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/eslint/node_modules/chalk": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3476,6 +3545,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/eslint/node_modules/p-limit": {
@@ -3891,6 +3972,28 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/glob/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/glob/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/globals": {
@@ -4844,15 +4947,18 @@
 			}
 		},
 		"node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+			"integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
 			"dev": true,
 			"dependencies": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "^2.0.1"
 			},
 			"engines": {
-				"node": "*"
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mocha": {
@@ -4949,6 +5055,16 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
+		"node_modules/mocha/node_modules/glob/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/mocha/node_modules/glob/node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -5007,15 +5123,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^1.0.0"
 			}
 		},
 		"node_modules/mocha/node_modules/ms": {
@@ -5111,9 +5218,9 @@
 			"dev": true
 		},
 		"node_modules/nodemon": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.2.tgz",
-			"integrity": "sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.3.tgz",
+			"integrity": "sha512-7jH/NXbFPxVaMwmBCC2B9F/V6X1VkEdNgx3iu9jji8WxWcvhMWkmhNWhI5077zknOnZnBzba9hZP6bCPJLSReQ==",
 			"dev": true,
 			"dependencies": {
 				"chokidar": "^3.5.2",
@@ -5138,6 +5245,16 @@
 				"url": "https://opencollective.com/nodemon"
 			}
 		},
+		"node_modules/nodemon/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
 		"node_modules/nodemon/node_modules/lru-cache": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -5148,6 +5265,18 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/nodemon/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/nodemon/node_modules/semver": {
@@ -6185,6 +6314,28 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/test-exclude/node_modules/brace-expansion": {
+			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
+			"dependencies": {
+				"balanced-match": "^1.0.0",
+				"concat-map": "0.0.1"
+			}
+		},
+		"node_modules/test-exclude/node_modules/minimatch": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
+			"dependencies": {
+				"brace-expansion": "^1.1.7"
+			},
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/text-table": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/marc-record-merge-js.git"
 	},
 	"license": "MIT",
-	"version": "7.0.2-alpha.1",
+	"version": "7.0.2-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"

--- a/package.json
+++ b/package.json
@@ -39,25 +39,25 @@
 		"dev:debug": "cross-env LOG_LEVEL=debug DEBUG=@natlibfi/* NODE_ENV=test nodemon"
 	},
 	"dependencies": {
-		"@natlibfi/marc-record": "^8.0.2",
+		"@natlibfi/marc-record": "^8.1.0",
 		"debug": "^4.3.4",
 		"normalize-diacritics": "^2.14.0"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.23.4",
-		"@babel/core": "^7.23.6",
-		"@babel/preset-env": "^7.23.6",
-		"@babel/register": "^7.22.15",
-		"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
-		"@natlibfi/fixugen": "^2.0.3",
-		"@natlibfi/fixura": "^3.0.3",
+		"@babel/core": "^7.23.7",
+		"@babel/preset-env": "^7.23.8",
+		"@babel/register": "^7.23.7",
+		"@natlibfi/eslint-config-melinda-backend": "^3.0.4",
+		"@natlibfi/fixugen": "^2.0.4",
+		"@natlibfi/fixura": "^3.0.4",
 		"babel-plugin-istanbul": "^6.1.1",
 		"babel-plugin-rewire": "^1.2.0",
-		"chai": "^4.3.10",
+		"chai": "^4.4.1",
 		"cross-env": "^7.0.3",
 		"eslint": "^8.56.0",
 		"mocha": "^10.2.0",
-		"nodemon": "^3.0.2",
+		"nodemon": "^3.0.3",
 		"nyc": "^15.1.0"
 	},
 	"eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/marc-record-merge-js.git"
 	},
 	"license": "MIT",
-	"version": "7.0.1",
+	"version": "7.0.2-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=18"


### PR DESCRIPTION
Bumps the production-dependencies group with 1 update: [@natlibfi/marc-record](https://github.com/natlibfi/marc-record-js).


Updates `@natlibfi/marc-record` from 8.0.2 to 8.1.0
- [Release notes](https://github.com/natlibfi/marc-record-js/releases)
- [Commits](https://github.com/natlibfi/marc-record-js/compare/v8.0.2...v8.1.0)

---
updated-dependencies:
- dependency-name: "@natlibfi/marc-record" dependency-type: direct:production update-type: version-update:semver-minor dependency-group: production-dependencies ...